### PR TITLE
Add a feature to look for errors

### DIFF
--- a/game/src/App.coffee
+++ b/game/src/App.coffee
@@ -147,7 +147,7 @@ class App
       y: (P1.y + P2.y) / 2
 
     # Determine the distance from M to P1
-    dMP1 = Math.sqrt((P1.x - M.x)*(P1.x - M.x) + (P1.y - M.y)*(P1.y - M.y))
+    dMP1 = Math.sqrt((P1.x - M.x) * (P1.x - M.x) + (P1.y - M.y) * (P1.y - M.y))
 
     # Validate the radius
     if not radius? or radius < dMP1
@@ -162,7 +162,7 @@ class App
     uMQ = { x: -uMP1.y, y: uMP1.x }
 
     # Determine the distance from the center of the circle (C) to M
-    dCM = Math.sqrt(radius*radius - dMP1*dMP1)
+    dCM = Math.sqrt(radius * radius - dMP1 * dMP1)
 
     # Determine the distance from M to Q
     dMQ = dMP1 * dMP1 / dCM
@@ -184,7 +184,7 @@ class App
   drawPoint: (x, y, r, color) ->
     @ctx.beginPath()
     @ctx.fillStyle = color
-    @ctx.arc(x, y, r, 0, 2*Math.PI)
+    @ctx.arc(x, y, r, 0, 2 * Math.PI)
     @ctx.fill()
     return
 
@@ -192,11 +192,11 @@ CanvasRenderingContext2D.prototype.roundRect = (x, y, w, h, r) ->
   if (w < 2 * r) then r = w / 2
   if (h < 2 * r) then r = h / 2
   @beginPath()
-  @moveTo(x+r, y)
-  @arcTo(x+w, y,   x+w, y+h, r)
-  @arcTo(x+w, y+h, x,   y+h, r)
-  @arcTo(x,   y+h, x,   y,   r)
-  @arcTo(x,   y,   x+w, y,   r)
+  @moveTo(x + r, y)
+  @arcTo(x + w, y,     x + w, y + h, r)
+  @arcTo(x + w, y + h, x,     y + h, r)
+  @arcTo(x,     y + h, x,     y,     r)
+  @arcTo(x,     y,     x + w, y,     r)
   @closePath()
   return this
 

--- a/game/src/SudokuGame.coffee
+++ b/game/src/SudokuGame.coffee
@@ -320,6 +320,27 @@ class SudokuGame
       links = []
     return links
 
+  markIsGood: (x, y, m) ->
+    # Check if this mark is a known value in the column
+    for j in [0...9] when j isnt y
+      if @grid[x][j].value == m
+        return false
+
+    # Check if this mark is a known value in the row
+    for i in [0...9] when i isnt x
+      if @grid[i][y].value == m
+        return false
+
+    # Check if this mark is a known value in the box
+    sx = Math.floor(x / 3) * 3
+    sy = Math.floor(y / 3) * 3
+    for i in [sx...sx + 3]
+      for j in [sy...sy + 3]
+        if (i != x || j != y) && @grid[i][j].value == m
+          return false
+  
+    return true
+
   newGame: (difficulty) ->
     console.log "newGame(#{difficulty})"
     for j in [0...9]
@@ -332,7 +353,7 @@ class SudokuGame
           cell.pencil[k] = false
 
     generator = new SudokuGenerator()
-    newGrid = generator.generate(difficulty)
+    [ newGrid, @solution ] = generator.generate(difficulty)
     # console.log "newGrid", newGrid
     for j in [0...9]
       for i in [0...9]
@@ -365,7 +386,7 @@ class SudokuGame
         dst.locked = if src.l > 0 then true else false
         for k in [0...9]
           dst.pencil[k] = if src.p[k] > 0 then true else false
-
+    @solution = gameData.solution
     @updateCells()
     console.log "Loaded game."
     return true
@@ -377,8 +398,11 @@ class SudokuGame
 
     gameData =
       grid: new Array(9).fill(null)
+      solution: new Array(9).fill(null)
+
     for i in [0...9]
       gameData.grid[i] = new Array(9).fill(null)
+      gameData.solution[i] = new Array(9).fill(null)
 
     for j in [0...9]
       for i in [0...9]
@@ -391,6 +415,11 @@ class SudokuGame
         dst = gameData.grid[i][j].p
         for k in [0...9]
           dst.push(if cell.pencil[k] then 1 else 0)
+
+    for i in [0...9]
+      gameData.solution[i] = new Array(9).fill(null)
+      for j in [0...9]
+        gameData.solution[i][j] = @solution[i][j]
 
     jsonString = JSON.stringify(gameData)
     localStorage.setItem("game", jsonString)

--- a/game/src/SudokuGame.coffee
+++ b/game/src/SudokuGame.coffee
@@ -15,7 +15,7 @@ ascendingLinkSort = (a, b) ->
 uniqueLinkFilter = (e, i, a) ->
   if i == 0
     return true
-  p = a[i-1]
+  p = a[i - 1]
   e0 = cellIndex(e.cells[0].x, e.cells[0].y)
   e1 = cellIndex(e.cells[1].x, e.cells[1].y)
   p0 = cellIndex(p.cells[0].x, p.cells[0].y)
@@ -25,8 +25,8 @@ uniqueLinkFilter = (e, i, a) ->
 generateLinkPermutations = (cells) ->
   links = []
   count = cells.length
-  for i in [0...count-1]
-    for j in [i+1...count]
+  for i in [0...count - 1]
+    for j in [i + 1...count]
       links.push({ cells: [cells[i], cells[j]] })
   return links
 
@@ -165,7 +165,7 @@ class SudokuGame
     for j in [0...9]
       for i in [0...9]
         if @grid[i][j].value != 0
-          counts[@grid[i][j].value-1] += 1
+          counts[@grid[i][j].value - 1] += 1
 
     for i in [0...9]
       if counts[i] == 9
@@ -186,7 +186,7 @@ class SudokuGame
       switch action
         when "togglePencil"
           journal.push { action: "togglePencil", x: x, y: y, values: values }
-          cell.pencil[v-1] = !cell.pencil[v-1] for v in values
+          cell.pencil[v - 1] = !cell.pencil[v - 1] for v in values
         when "setValue"
           journal.push { action: "setValue", x: x, y: y, values: [cell.value] }
           cell.value = values[0]
@@ -209,7 +209,7 @@ class SudokuGame
     cell = @grid[x][y]
     if cell.locked
       return
-    @do "togglePencil", x, y, (i+1 for flag, i in cell.pencil when flag), @undoJournal
+    @do "togglePencil", x, y, (i + 1 for flag, i in cell.pencil when flag), @undoJournal
     @redoJournal = []
 
   togglePencil: (x, y, v) ->
@@ -272,11 +272,11 @@ class SudokuGame
 
     return { strong, weak }
 
-  getRowLinks: (y, value)->
+  getRowLinks: (y, value) ->
     cells = []
     for x in [0...9]
       cell = @grid[x][y]
-      if cell.value == 0 and cell.pencil[value-1]
+      if cell.value == 0 and cell.pencil[value - 1]
         cells.push({ x, y })
 
     if cells.length > 1
@@ -287,11 +287,11 @@ class SudokuGame
       links = []
     return links
 
-  getColumnLinks: (x, value)->
+  getColumnLinks: (x, value) ->
     cells = []
     for y in [0...9]
       cell = @grid[x][y]
-      if cell.value == 0 and cell.pencil[value-1]
+      if cell.value == 0 and cell.pencil[value - 1]
         cells.push({ x, y })
 
     if cells.length > 1
@@ -306,10 +306,10 @@ class SudokuGame
     cells = []
     sx = boxX * 3
     sy = boxY * 3
-    for y in [sy...sy+3]
-      for x in [sx...sx+3]
+    for y in [sy...sy + 3]
+      for x in [sx...sx + 3]
         cell = @grid[x][y]
-        if cell.value == 0 and cell.pencil[value-1]
+        if cell.value == 0 and cell.pencil[value - 1]
           cells.push({ x, y })
 
     if cells.length > 1

--- a/game/src/SudokuGenerator.coffee
+++ b/game/src/SudokuGenerator.coffee
@@ -9,7 +9,7 @@ shuffle = (a) ->
 
 class Board
   constructor: (otherBoard = null) ->
-    @lockedCount = 0;
+    @lockedCount = 0
     @grid = new Array(9).fill(null)
     @locked = new Array(9).fill(null)
     for i in [0...9]
@@ -34,7 +34,7 @@ class Board
       @lockedCount += 1 if not @locked[x][y]
     else
       @lockedCount -= 1 if @locked[x][y]
-    @locked[x][y] = v;
+    @locked[x][y] = v
 
 
 class SudokuGenerator
@@ -150,7 +150,7 @@ class SudokuGenerator
     return true if unlockedCount == 0
 
     # check for a second solution
-    return @solveInternal(solved, attempts, unlockedCount-1) == null
+    return @solveInternal(solved, attempts, unlockedCount - 1) == null
 
   solveInternal: (solved, attempts, walkIndex = 0) ->
     unlockedCount = 81 - solved.lockedCount

--- a/game/src/SudokuGenerator.coffee
+++ b/game/src/SudokuGenerator.coffee
@@ -186,6 +186,8 @@ class SudokuGenerator
       for i in [0...9]
         board.lock(i, j)
 
+    solution = new Board(board)
+
     indexesToRemove = shuffle([0...81])
     removed = 0
     while removed < amountToRemove
@@ -208,8 +210,9 @@ class SudokuGenerator
         # console.log "failed to remove #{rx},#{ry}, creates non-unique solution"
 
     return {
-      board: board
-      removed: removed
+      board
+      removed
+      solution
     }
 
   generate: (difficulty) ->
@@ -234,7 +237,7 @@ class SudokuGenerator
       console.log "current best #{best.removed} / #{amountToRemove}"
 
     console.log "giving user board: #{best.removed} / #{amountToRemove}"
-    return @boardToGrid(best.board)
+    return [@boardToGrid(best.board), @boardToGrid(best.solution)]
 
   validateGrid: (grid) ->
     return @hasUniqueSolution(@gridToBoard(grid))

--- a/game/src/SudokuView.coffee
+++ b/game/src/SudokuView.coffee
@@ -182,7 +182,7 @@ class SudokuView
     @actions[index] = { type: ActionType.REDO }
 
     # Mode switch
-    for i in [(MODE_POS_Y*9)+MODE_START_POS_X..(MODE_POS_Y*9)+MODE_END_POS_X]
+    for i in [(MODE_POS_Y * 9) + MODE_START_POS_X..(MODE_POS_Y * 9) + MODE_END_POS_X]
       @actions[i] = { type: ActionType.MODE }
 
     return

--- a/game/src/SudokuView.coffee
+++ b/game/src/SudokuView.coffee
@@ -557,6 +557,7 @@ class SudokuView
           @highlightingValues = false
           @lastValueTapMS = now()
           @penValue = action.value
+        @preferPencil = true # Make sure the keyboard is also in pencil mode
 
       # Otherwise, switch to PENCIL
       else
@@ -568,6 +569,7 @@ class SudokuView
           @lastValueTapMS = now()
         @mode = ModeType.PENCIL
         @penValue = action.value
+        @preferPencil = true # Make sure the keyboard is also in pencil mode
     return
 
   handlePenAction: (action) ->
@@ -587,6 +589,7 @@ class SudokuView
           @highlightingValues = false
           @lastValueTapMS = now()
           @penValue = action.value
+        @preferPencil = false # Make sure the keyboard is also in pen mode
 
       # Ignored in LINKS
       when ModeType.LINKS
@@ -602,6 +605,7 @@ class SudokuView
           @lastValueTapMS = now()
         @mode = ModeType.PEN
         @penValue = action.value
+        @preferPencil = false # Make sure the keyboard is also in pen mode
 
     # Make sure any visibility highlighting is off and links are cleared.
     @visibilityX = -1

--- a/game/src/websolver.coffee
+++ b/game/src/websolver.coffee
@@ -8,7 +8,7 @@ window.qs = (name) ->
   url = window.location.href
   name = name.replace(/[\[\]]/g, '\\$&')
   regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
-  results = regex.exec(url);
+  results = regex.exec(url)
   if not results or not results[2]
     return null
   return decodeURIComponent(results[2].replace(/\+/g, ' '))


### PR DESCRIPTION
Primarily, this implements a feature that checks for errors, but there are also changes to keyboard behavior and how links are drawn.

### Minor changes to make coffeelint happy
Mostly the addition of spaces and removal of semicolons

### Fixed keyboard behavior when in Links mode
I changed how links are drawn so that they aren't as curved and they stay within a row or column.
The keyboard did nothing in Links mode. Now it is active.

### Added check mode.
When you click on the check mark, the game will look for errors and highlight:
1. A pencil mark that is not possible because a square in the row, column, or box has that value.
2. A square set to an incorrect value according to the solution.

The highlighting goes away as soon as you switch to a different mode.

### Keyboard now switches to pen or pencil after clicking on pen or pencil
Previously, if your keyboard entry was in pen mode and you click to switch to pencil mode, then any keyboard entry will switch back to pen mode, and vice versa. This change unifies the two.